### PR TITLE
Add basic gui page keynav support to webplayer and fullscreen mode

### DIFF
--- a/ovos_plugin_common_play/ocp/res/ui/+mediacenter/OVOSWebPlayer.qml
+++ b/ovos_plugin_common_play/ocp/res/ui/+mediacenter/OVOSWebPlayer.qml
@@ -44,7 +44,6 @@ Mycroft.Delegate {
 
         onLoadingChanged: {
             if(loadRequest.status == WebEngineView.LoadSucceededStatus && sessionData.javascript){
-                webview.runJavaScript("useFullscreen()")
                 webview.runJavaScript(sessionData.javascript, function(result) { console.log(result); })
             }
         }

--- a/ovos_plugin_common_play/ocp/res/ui/+mediacenter/OVOSWebPlayer.qml
+++ b/ovos_plugin_common_play/ocp/res/ui/+mediacenter/OVOSWebPlayer.qml
@@ -11,11 +11,19 @@ Mycroft.Delegate {
     id: root
     fillWidth: true
     property var pageUrl: sessionData.uri
-
+    
     onPageUrlChanged: {
         console.log("opening webview from mediacenter")
         console.log(pageUrl)
         webview.url = pageUrl
+    }
+
+    function viewLeftPressed() {
+        parent.parent.parent.currentIndex--
+    }
+
+    function viewRightPressed() {
+        parent.parent.parent.currentIndex++
     }
 
     WebEngineView {
@@ -56,7 +64,7 @@ Mycroft.Delegate {
                 request.openIn(webview);
             }
         }
-
+        
         onJavaScriptDialogRequested: function(request) {
             request.accepted = true;
         }
@@ -67,6 +75,12 @@ Mycroft.Delegate {
 
         onJavaScriptConsoleMessage: {
             console.log(message)
+            if(message == "rightPageRequested") {
+                viewRightPressed()
+            }
+            if(message == "leftPageRequested") {
+                viewLeftPressed()
+            }
         }
     }
-}
+} 

--- a/ovos_plugin_common_play/ocp/res/ui/+mediacenter/OVOSWebPlayer.qml
+++ b/ovos_plugin_common_play/ocp/res/ui/+mediacenter/OVOSWebPlayer.qml
@@ -11,6 +11,7 @@ Mycroft.Delegate {
     id: root
     fillWidth: true
     property var pageUrl: sessionData.uri
+    skillBackgroundSource: "black"
     
     onPageUrlChanged: {
         console.log("opening webview from mediacenter")

--- a/ovos_plugin_common_play/ocp/res/ui/OVOSWebPlayer.qml
+++ b/ovos_plugin_common_play/ocp/res/ui/OVOSWebPlayer.qml
@@ -11,6 +11,7 @@ Mycroft.Delegate {
     id: root
     fillWidth: true
     property var pageUrl: sessionData.uri
+    skillBackgroundSource: "black"
 
     onPageUrlChanged: {
         console.log("opening webview from mediacenter")

--- a/ovos_plugin_common_play/ocp/res/ui/OVOSWebPlayer.qml
+++ b/ovos_plugin_common_play/ocp/res/ui/OVOSWebPlayer.qml
@@ -36,7 +36,6 @@ Mycroft.Delegate {
 
         onLoadingChanged: {
             if(loadRequest.status == WebEngineView.LoadSucceededStatus && sessionData.javascript){
-                webview.runJavaScript("useFullscreen()")
                 webview.runJavaScript(sessionData.javascript, function(result) { console.log(result); })
             }
         }

--- a/ovos_plugin_common_play/ocp/res/ui/code/nav.js
+++ b/ovos_plugin_common_play/ocp/res/ui/code/nav.js
@@ -1,0 +1,46 @@
+document.onkeydown = function(e) {
+    switch (e.keyCode) {
+        case 37:
+            console.log('leftPageRequested');
+            break;
+        case 39:
+            console.log('rightPageRequested');
+            break;
+    }
+};
+
+function useFullscreen() {
+    var video = document.querySelector('video'); 
+    var controlBar = findControlBar();
+
+    while (document.body.firstChild) { 
+      document.body.removeChild(document.body.firstChild);
+     }; 
+     document.body.appendChild(video);
+     document.body.appendChild(controlBar);
+     document.body.style.overflow = 'hidden';
+     changeBackground();
+     video.style.background = "black";
+     video.play();
+     hideScrollbar();
+}
+
+// Find element which contains control-bar
+function findControlBar() {
+    var allElements = document.querySelectorAll('*');
+    for (var i = 0; i < allElements.length; i++) {
+        if (allElements[i].className.indexOf('control-bar') != -1) {
+            return allElements[i];
+        }
+    }
+}
+
+function hideScrollbar() {
+    var style = document.createElement("style");
+    style.innerHTML = `body::-webkit-scrollbar {display: none;}`;
+    document.head.appendChild(style);
+}
+
+function changeBackground() {
+    document.body.style.background = "black";
+ }


### PR DESCRIPTION
- Add left and right key navigation when web view gets focus so can switch between gui pages under mediacenter file selector
- Add experimental fullscreen mode which will only display the html5 video element with it control bars
- Move execution of skill JS to loaded status so skill JS does not error out when elements aren't finished loading