### PR TITLE
Fix/stream xtract/yt channel live

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -24,8 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
       - name: Setup Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/notify_matrix.yml
+++ b/.github/workflows/notify_matrix.yml
@@ -1,0 +1,23 @@
+name: Notify Matrix Chat
+
+# only trigger on pull request closed events
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  merge_job:
+    # this job will only run if the PR has been merged
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Send message to Matrix bots channel
+        id: matrix-chat-message
+        uses: fadenb/matrix-chat-message@v0.0.6
+        with:
+          homeserver: 'matrix.org'
+          token: ${{ secrets.MATRIX_TOKEN }}
+          channel: '!WjxEKjjINpyBRPFgxl:krbel.duckdns.org'
+          message: |
+            new ovos-ocp-audio-plugin PR merged! https://github.com/OpenVoiceOS/ovos-ocp-audio-plugin/pull/${{ github.event.number }}

--- a/ovos_plugin_common_play/ocp/media.py
+++ b/ovos_plugin_common_play/ocp/media.py
@@ -323,7 +323,7 @@ class NowPlaying(MediaEntry):
         elif uri.startswith("youtube.channel.live//"):
             uri = uri.replace("youtube.channel.live//", "")
             uri = get_youtube_live_from_channel(
-                uri, backend=self._settings.yt_chlive_backend)["url"]
+                uri, ocp_settings=self._settings)["url"]
             if not uri:
                 LOG.error("youtube channel live stream extraction failed!!!")
             else:

--- a/ovos_plugin_common_play/ocp/settings.py
+++ b/ovos_plugin_common_play/ocp/settings.py
@@ -186,6 +186,18 @@ class OCPSettings(PrivateSettings):
         return self.get("invidious_proxy", False)
 
     @property
+    def yt_chlive_backend(self):
+        """class YoutubeLiveBackend(str, enum.Enum):
+        PYTUBE = "pytube"
+        YT_SEARCHER = "youtube_searcher"
+        REDIRECT = "redirect"  <- default
+            # uses youtube auto redirect https://www.youtube.com/{channel_name}/live
+        YDL = "youtube-dl"
+            # same as above, but always uses YoutubeBackend.YDL internally
+        """
+        return self.get("youtube_backend") or YoutubeBackend.PYTUBE
+
+    @property
     def ydl_backend(self):
         """class YdlBackend(str, enum.Enum):
         YDL = "youtube-dl"

--- a/ovos_plugin_common_play/ocp/settings.py
+++ b/ovos_plugin_common_play/ocp/settings.py
@@ -186,14 +186,6 @@ class OCPSettings(PrivateSettings):
         return self.get("invidious_proxy", False)
 
     @property
-    def yt_chlive_backend(self):
-        """class YoutubeLiveBackend(str, enum.Enum):
-        PYTUBE = "pytube" <- default
-        YT_SEARCHER = "youtube_searcher"
-        """
-        return self.get("youtube_backend") or YoutubeBackend.PYTUBE
-
-    @property
     def ydl_backend(self):
         """class YdlBackend(str, enum.Enum):
         YDL = "youtube-dl"

--- a/ovos_plugin_common_play/ocp/settings.py
+++ b/ovos_plugin_common_play/ocp/settings.py
@@ -3,7 +3,7 @@ import requests
 from ovos_plugin_common_play.ocp.status import MediaType, PlaybackMode
 from ovos_utils.skills.settings import PrivateSettings
 from ovos_plugin_common_play.ocp.stream_handlers import YoutubeBackend, \
-    BandcampBackend, YdlBackend
+    BandcampBackend, YdlBackend, YoutubeLiveBackend
 from dbus_next.constants import BusType
 
 
@@ -195,7 +195,7 @@ class OCPSettings(PrivateSettings):
         YDL = "youtube-dl"
             # same as above, but always uses YoutubeBackend.YDL internally
         """
-        return self.get("youtube_backend") or YoutubeBackend.PYTUBE
+        return self.get("youtube_live_backend") or YoutubeLiveBackend.REDIRECT
 
     @property
     def ydl_backend(self):

--- a/ovos_plugin_common_play/ocp/stream_handlers/youtube.py
+++ b/ovos_plugin_common_play/ocp/stream_handlers/youtube.py
@@ -293,13 +293,3 @@ def get_youtubesearcher_channel_livestreams(url):
             }
     except:
         pass
-
-
-if __name__ == "__main__":
-    urls = ["https://www.youtube.com/c/euronewsportugues",
-            "https://www.youtube.com/channel/euronewsportugues",
-            "https://www.youtube.com/EuronewsUSA",
-            "https://www.youtube.com/c/EuronewsUSA",
-            "https://www.youtube.com/channel/EuronewsUSA"]
-    for url in urls:
-        print(get_youtube_live_from_channel(url))

--- a/ovos_plugin_common_play/ocp/stream_handlers/youtube.py
+++ b/ovos_plugin_common_play/ocp/stream_handlers/youtube.py
@@ -52,7 +52,7 @@ def _parse_title(title):
 
 def get_youtube_live_from_channel(url, ocp_settings=None):
     settings = ocp_settings or {}
-    backend = settings.get("youtube_backend") or YoutubeLiveBackend.REDIRECT
+    backend = settings.get("youtube_live_backend") or YoutubeLiveBackend.REDIRECT
     if backend == YoutubeLiveBackend.YT_SEARCHER:
         extractor = get_youtubesearcher_channel_livestreams
     elif backend == YoutubeLiveBackend.PYTUBE:

--- a/ovos_plugin_common_play/ocp/stream_handlers/youtube.py
+++ b/ovos_plugin_common_play/ocp/stream_handlers/youtube.py
@@ -19,6 +19,13 @@ class YdlBackend(str, enum.Enum):
     AUTO = "auto"
 
 
+class YoutubeLiveBackend(str, enum.Enum):
+    REDIRECT = "redirect"  # url = f"https://www.youtube.com/c/{channel_name}/live"
+    YDL = "youtube-dl"  # same as above, but always uses YoutubeBackend.YDL internally
+    PYTUBE = "pytube"
+    YT_SEARCHER = "youtube_searcher"
+
+
 def _parse_title(title):
     # try to extract_streams artist from title
     delims = [":", "|", "-"]
@@ -44,25 +51,19 @@ def _parse_title(title):
 
 
 def get_youtube_live_from_channel(url, ocp_settings=None):
-    # TODO improve channel name handling
-    url = url.split("?")[0]
-    if "/c/" in url or "/channel/" in url or "/user/" in url:
-        channel_name = url.split("/channel/")[-1].split("/c/")[-1].split("/user/")[-1].split("/")[0]
+    settings = ocp_settings or {}
+    backend = settings.get("youtube_backend") or YoutubeLiveBackend.REDIRECT
+    if backend == YoutubeLiveBackend.YT_SEARCHER:
+        extractor = get_youtubesearcher_channel_livestreams
+    elif backend == YoutubeLiveBackend.PYTUBE:
+        extractor = get_pytube_channel_livestreams
+    elif backend == YoutubeLiveBackend.YDL:
+        ocp_settings = dict(ocp_settings)
+        ocp_settings["youtube_backend"] = YoutubeBackend.YDL
+        extractor = get_youtube_live_from_channel_redirect
     else:
-        channel_name = url.split("/")[-1]
-
-    # we see different patterns randomly used in the wild
-    # i do not know a easy way to check which are valid for a channel
-    # lazily try: except: and hail mary
-    # TODO invidious backend can not handle channels
-    try:
-        # seems to work for all channels
-        url = f"https://www.youtube.com/{channel_name}/live"
-        return get_youtube_stream(url, ocp_settings=ocp_settings)
-    except:
-        # works for some channels only
-        url = f"https://www.youtube.com/c/{channel_name}/live"
-        return get_youtube_stream(url, ocp_settings=ocp_settings)
+        extractor = get_youtube_live_from_channel_redirect
+    return extractor(url, ocp_settings=settings)
 
 
 def get_youtube_stream(url,
@@ -259,7 +260,7 @@ def get_pytube_stream(url, audio_only=False, ocp_settings=None, best=True):
     return info
 
 
-def get_pytube_channel_livestreams(url):
+def get_pytube_channel_livestreams(url, ocp_settings=None):
     from pytube import Channel
     yt = Channel(url)
     for v in yt.videos_generator():
@@ -275,7 +276,7 @@ def get_pytube_channel_livestreams(url):
             }
 
 
-def get_youtubesearcher_channel_livestreams(url):
+def get_youtubesearcher_channel_livestreams(url, ocp_settings=None):
     LOG.warning("youtube_searcher is abandonware, support will be removed in the next release")
     try:
         from youtube_searcher import extract_videos
@@ -293,3 +294,25 @@ def get_youtubesearcher_channel_livestreams(url):
             }
     except:
         pass
+
+
+def get_youtube_live_from_channel_redirect(url, ocp_settings=None):
+    # TODO improve channel name handling
+    url = url.split("?")[0]
+    if "/c/" in url or "/channel/" in url or "/user/" in url:
+        channel_name = url.split("/channel/")[-1].split("/c/")[-1].split("/user/")[-1].split("/")[0]
+    else:
+        channel_name = url.split("/")[-1]
+
+    # we see different patterns randomly used in the wild
+    # i do not know a easy way to check which are valid for a channel
+    # lazily try: except: and hail mary
+    # TODO invidious backend can not handle channels
+    try:
+        # seems to work for all channels
+        url = f"https://www.youtube.com/{channel_name}/live"
+        return get_youtube_stream(url, ocp_settings=ocp_settings)
+    except:
+        # works for some channels only
+        url = f"https://www.youtube.com/c/{channel_name}/live"
+        return get_youtube_stream(url, ocp_settings=ocp_settings)


### PR DESCRIPTION
the youtube live from channel stream extractor was never fully completed and really a proof of concept, this PR refactors it to be part of the regular youtube integration and no longer a special case

- refactor live stream extractor
   - fix reading extractor backend from config
   - modernizes the extractor to match the other ones (ocp_settings kwarg)
   - add new default youtube url extractor via youtube auto redirect url `https://www.youtube.com/{channel_name}/live`
   - add explicit config support for youtube-dl via the above method
   - deprecate support for youtube_searcher package, it is abandonware (i am the author, no more updates coming ever)
- improve invidious support
    - refactor invidious extractor to use the json api
    - fix the default url when not set in config (direct usage of extractor methods)
    - set invidious as default instead of youtube-dl when not set in config (direct usage of extractor methods)
    - fallback to youtube-dl for lives (live streams in invidious are broken)
- add workflow for matrix chat, because i had this local unpushed change :)

test code
```python
urls = ["https://www.youtube.com/c/euronewsportugues",
        "https://www.youtube.com/channel/euronewsportugues",
        "https://www.youtube.com/EuronewsUSA",
        "https://www.youtube.com/c/EuronewsUSA",
        "https://www.youtube.com/channel/EuronewsUSA"]
for url in urls:
    print(get_youtube_live_from_channel(url))
```