### PR TITLE
Add application view timeout configuration option and handling

### DIFF
--- a/ovos_plugin_common_play/ocp/gui.py
+++ b/ovos_plugin_common_play/ocp/gui.py
@@ -2,6 +2,7 @@ from os.path import join, dirname
 from time import sleep, time
 from mycroft_bus_client.message import Message
 from ovos_utils.gui import GUIInterface
+from ovos_utils.events import EventSchedulerInterface
 from ovos_utils.log import LOG
 from ovos_config import Configuration
 
@@ -21,6 +22,7 @@ class OCPMediaPlayerGUI(GUIInterface):
         self.notification_timeout = None
         self.search_mode_is_app = False
         self.persist_home_display = False
+        self.event_scheduler_interface = None
 
     def bind(self, player):
         self.player = player
@@ -33,6 +35,7 @@ class OCPMediaPlayerGUI(GUIInterface):
                               self.handle_play_from_search)
         self.player.add_event('ovos.common_play.skill.play',
                               self.handle_play_skill_featured_media)
+        self.event_scheduler_interface = EventSchedulerInterface(name="ovos.common_play", bus=self.bus)
 
     @property
     def home_screen_page(self):
@@ -170,6 +173,9 @@ class OCPMediaPlayerGUI(GUIInterface):
         player_status = self.player.state
         state2str = {PlayerState.PLAYING: "Playing", PlayerState.PAUSED: "Paused", PlayerState.STOPPED: "Stopped"}
         self["status"] = state2str[player_status]
+        self["app_view_timeout_enabled"] = self.player.app_view_timeout_enabled
+        self["app_view_timeout"] = self.player.app_view_timeout_value
+        self["app_view_timeout_mode"] = self.player.app_view_timeout_mode
 
         LOG.debug(f"manage_display: page_requested: {page_requested}")
         LOG.debug(f"manage_display: player_status: {player_status}")
@@ -211,9 +217,24 @@ class OCPMediaPlayerGUI(GUIInterface):
             else:
                 self.show_page(self.disambiguation_playlists_page, override_idle=True, override_animations=True)
 
-        if self.player.enable_app_view_timeout and page_requested == "player":
-            self.player.event_scheduler_interface.schedule_event(
-                self.timeout_app_view, 30, data=None, name="ocp_app_view_timer")
+        if (self.player.app_view_timeout_enabled and page_requested == "player"
+                and self.player.app_view_timeout_mode == "all"):
+            self.schedule_app_view_timeout()
+
+    def cancel_app_view_timeout(self, restart=False):
+        self.event_scheduler_interface.cancel_scheduled_event("ocp_app_view_timer")
+        if restart:
+            self.schedule_app_view_timeout()
+
+    def schedule_app_view_pause_timeout(self):
+        if (self.player.app_view_timeout_enabled
+            and self.player.app_view_timeout_mode == "pause"
+                and self.player.state == PlayerState.PAUSED):
+            self.schedule_app_view_timeout()
+
+    def schedule_app_view_timeout(self):
+        self.event_scheduler_interface.schedule_event(
+            self.timeout_app_view, self.player.app_view_timeout_value, data=None, name="ocp_app_view_timer")
 
     def timeout_app_view(self):
         self.bus.emit(Message("homescreen.manager.show_active"))
@@ -233,9 +254,9 @@ class OCPMediaPlayerGUI(GUIInterface):
         else:
             self.persist_home_display = False
 
-        if self.player.state == PlayerState.PLAYING and self.player.enable_app_view_timeout:
-            self.player.event_scheduler_interface.schedule_event(
-                self.timeout_app_view, self.player.app_view_timeout, data=None, name="ocp_app_view_timer")
+        if (self.player.state == PlayerState.PLAYING and self.player.app_view_timeout_enabled
+                and self.player.app_view_timeout_mode == "all"):
+            self.schedule_app_view_timeout()
 
     def release(self):
         self.clear()

--- a/ovos_plugin_common_play/ocp/gui.py
+++ b/ovos_plugin_common_play/ocp/gui.py
@@ -210,7 +210,14 @@ class OCPMediaPlayerGUI(GUIInterface):
                 self.show_page(self.disambiguation_playlists_page, override_idle=timeout, override_animations=True)
             else:
                 self.show_page(self.disambiguation_playlists_page, override_idle=True, override_animations=True)
-                
+
+        if self.player.enable_app_view_timeout and page_requested == "player":
+            self.player.event_scheduler_interface.schedule_event(
+                self.timeout_app_view, 30, data=None, name="ocp_app_view_timer")
+
+    def timeout_app_view(self):
+        self.bus.emit(Message("homescreen.manager.show_active"))
+
     def unload_player_loader(self):
         self.send_event("ocp.gui.player.loader.clear")
 

--- a/ovos_plugin_common_play/ocp/gui.py
+++ b/ovos_plugin_common_play/ocp/gui.py
@@ -224,14 +224,18 @@ class OCPMediaPlayerGUI(GUIInterface):
     def show_home(self, app_mode=True):
         self.update_ocp_skills()
         self.clear_notification()
-        
+
         sleep(0.2)
         self.manage_display("home")
-        
+
         if app_mode:
             self.persist_home_display = True
         else:
-            self.persist_home_display = False       
+            self.persist_home_display = False
+
+        if self.player.state == PlayerState.PLAYING and self.player.enable_app_view_timeout:
+            self.player.event_scheduler_interface.schedule_event(
+                self.timeout_app_view, 30, data=None, name="ocp_app_view_timer")
 
     def release(self):
         self.clear()

--- a/ovos_plugin_common_play/ocp/gui.py
+++ b/ovos_plugin_common_play/ocp/gui.py
@@ -235,7 +235,7 @@ class OCPMediaPlayerGUI(GUIInterface):
 
         if self.player.state == PlayerState.PLAYING and self.player.enable_app_view_timeout:
             self.player.event_scheduler_interface.schedule_event(
-                self.timeout_app_view, 30, data=None, name="ocp_app_view_timer")
+                self.timeout_app_view, self.player.app_view_timeout, data=None, name="ocp_app_view_timer")
 
     def release(self):
         self.clear()

--- a/ovos_plugin_common_play/ocp/player.py
+++ b/ovos_plugin_common_play/ocp/player.py
@@ -44,6 +44,7 @@ class OCPMediaPlayer(OVOSAbstractApplication):
         self.track_history = {}
         self.event_scheduler_interface = EventSchedulerInterface(name="ovos.common_play", bus=bus)
         self.enable_app_view_timeout = settings.get("enable_app_view_timeout", False)
+        self.app_view_timeout = settings.get("app_view_timeout", 30)
         super().__init__("ovos_common_play", settings=settings, bus=bus,
                          gui=gui, resources_dir=resources_dir, lang=lang)
 
@@ -127,6 +128,8 @@ class OCPMediaPlayer(OVOSAbstractApplication):
         # GUI Configuration Events
         self.add_event('ovos.common_play.gui.enable_app_timeout',
                        self.handle_enable_app_timeout)
+        self.add_event('ovos.common_play.gui.set_app_timeout',
+                       self.handle_set_app_timeout)
 
     @property
     def active_skill(self):
@@ -698,3 +701,8 @@ class OCPMediaPlayer(OVOSAbstractApplication):
         self.settings["enable_app_view_timeout"] = message.data.get("enabled", False)
         self.settings.store()
         self.enable_app_view_timeout = self.settings["enable_app_view_timeout"]
+    
+    def handle_set_app_timeout(self, message):
+        self.settings["app_view_timeout"] = message.data.get("timeout", 30)
+        self.settings.store()
+        self.app_view_timeout = self.settings["app_view_timeout"]

--- a/ovos_plugin_common_play/ocp/res/ui/ConfigButtonDelegate.qml
+++ b/ovos_plugin_common_play/ocp/res/ui/ConfigButtonDelegate.qml
@@ -1,0 +1,79 @@
+import QtQuick.Layouts 1.4
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import org.kde.kirigami 2.10 as Kirigami
+import Mycroft 1.0 as Mycroft
+
+Rectangle {
+    id: displaySettingItemControl
+    Layout.fillWidth: true
+    Layout.preferredHeight: displaySettingItemLabel.implicitHeight + Mycroft.Units.gridUnit
+    color: Qt.lighter(Kirigami.Theme.backgroundColor, 2)
+    border.width: 1
+    border.color: Qt.darker(Kirigami.Theme.textColor, 1.5)
+    radius: 6
+    property alias label: settingLabel.text
+    property alias description: settingDescription.text
+    property alias checked: displaySettingItemSwitchButton.checked
+    property alias switchLabel: displaySettingItemSwitchButton.text
+    property alias switchColor: displaySettingItemSwitchIcon.color
+    property var guiEvent: null
+    property var guiEventData: {}
+
+
+    ColumnLayout {
+        id: displaySettingItemLabel
+        anchors.left: parent.left
+        anchors.right: displaySettingItemSwitchButton.left
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.leftMargin: Mycroft.Units.gridUnit / 2
+
+        Label {
+            id: settingLabel
+            font.pixelSize: 18
+            fontSizeMode: Text.Fit
+            minimumPixelSize: 14
+            color: Kirigami.Theme.textColor
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.alignment: Qt.AlignLeft
+        }
+
+        Label {
+            id: settingDescription
+            font.pixelSize: settingOneLabel.font.pixelSize / 1.5
+            color: Kirigami.Theme.textColor
+            wrapMode: Text.WordWrap
+            elide: Text.ElideRight
+            maximumLineCount: 1
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.alignment: Qt.AlignLeft
+        }
+    }
+
+    Button {
+        id: displaySettingItemSwitchButton
+        width: Mycroft.Units.gridUnit * 10
+        anchors.right: parent.right
+        anchors.rightMargin: Mycroft.Units.gridUnit / 2
+        height: parent.height - Mycroft.Units.gridUnit / 2
+        anchors.verticalCenter: parent.verticalCenter
+        checkable: true
+        text: displaySettingItemControl.checked ? qsTr("ON") : qsTr("OFF")
+
+        Rectangle {
+            id: displaySettingItemSwitchIcon
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.right: parent.right
+            anchors.rightMargin: 8
+            height: Kirigami.Units.iconSizes.small
+            width: Kirigami.Units.iconSizes.small
+            radius: 1000
+        }
+
+        onClicked: {
+             Mycroft.MycroftController.sendRequest(displaySettingItemControl.guiEvent, displaySettingItemControl.guiEventData)
+        }
+    }
+}

--- a/ovos_plugin_common_play/ocp/res/ui/ConfigDelegateLayoutItem.qml
+++ b/ovos_plugin_common_play/ocp/res/ui/ConfigDelegateLayoutItem.qml
@@ -4,27 +4,26 @@ import QtQuick.Controls 2.12
 import org.kde.kirigami 2.10 as Kirigami
 import Mycroft 1.0 as Mycroft
 
-Rectangle {
+ItemDelegate {
     id: displaySettingItemControl
     Layout.fillWidth: true
     Layout.preferredHeight: displaySettingItemLabel.implicitHeight + Mycroft.Units.gridUnit
-    color: Qt.lighter(Kirigami.Theme.backgroundColor, 2)
-    border.width: 1
-    border.color: Qt.darker(Kirigami.Theme.textColor, 1.5)
-    radius: 6
     property alias label: settingLabel.text
     property alias description: settingDescription.text
-    property alias checked: displaySettingItemSwitchButton.checked
-    property alias switchLabel: displaySettingItemSwitchButton.text
-    property alias switchColor: displaySettingItemSwitchIcon.color
-    property var guiEvent: null
-    property var guiEventData: {}
+    property var contentItemWidth: Mycroft.Units.gridUnit * 10
 
+    background: Rectangle {
+        color: Qt.lighter(Kirigami.Theme.backgroundColor, 2)
+        border.width: 1
+        border.color: Qt.darker(Kirigami.Theme.textColor, 1.5)
+        radius: 6
+    }
 
     ColumnLayout {
         id: displaySettingItemLabel
         anchors.left: parent.left
-        anchors.right: displaySettingItemSwitchButton.left
+        anchors.right: parent.right
+        anchors.rightMargin: contentItemWidth + (Mycroft.Units.gridUnit / 2)
         anchors.verticalCenter: parent.verticalCenter
         anchors.leftMargin: Mycroft.Units.gridUnit / 2
 
@@ -52,28 +51,13 @@ Rectangle {
         }
     }
 
-    Button {
-        id: displaySettingItemSwitchButton
-        width: Mycroft.Units.gridUnit * 10
+    contentItem: Item {
+        id: contentItemMainElement
         anchors.right: parent.right
         anchors.rightMargin: Mycroft.Units.gridUnit / 2
         height: parent.height - Mycroft.Units.gridUnit / 2
+        width: contentItemWidth
         anchors.verticalCenter: parent.verticalCenter
-        checkable: true
-        text: displaySettingItemControl.checked ? qsTr("ON") : qsTr("OFF")
-
-        Rectangle {
-            id: displaySettingItemSwitchIcon
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.right: parent.right
-            anchors.rightMargin: 8
-            height: Kirigami.Units.iconSizes.small
-            width: Kirigami.Units.iconSizes.small
-            radius: 1000
-        }
-
-        onClicked: {
-             Mycroft.MycroftController.sendRequest(displaySettingItemControl.guiEvent, displaySettingItemControl.guiEventData)
-        }
+        z: 2
     }
 }

--- a/ovos_plugin_common_play/ocp/res/ui/ConfigOptionDelegate.qml
+++ b/ovos_plugin_common_play/ocp/res/ui/ConfigOptionDelegate.qml
@@ -1,0 +1,16 @@
+import QtQuick.Layouts 1.4
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import org.kde.kirigami 2.10 as Kirigami
+import Mycroft 1.0 as Mycroft
+
+ComboBox {
+    id: combobox
+    anchors.right: parent.right
+    anchors.rightMargin: Mycroft.Units.gridUnit / 2
+    height: parent.height - Mycroft.Units.gridUnit / 2
+    width: parent.contentItemWidth
+    anchors.verticalCenter: parent.verticalCenter
+    property var guiEvent: null
+    property var guiEventData: {}
+}

--- a/ovos_plugin_common_play/ocp/res/ui/ConfigSliderDelegate.qml
+++ b/ovos_plugin_common_play/ocp/res/ui/ConfigSliderDelegate.qml
@@ -1,0 +1,43 @@
+import QtQuick.Layouts 1.4
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import org.kde.kirigami 2.10 as Kirigami
+import Mycroft 1.0 as Mycroft
+
+
+Slider {
+    id: displaySettingItemSwitchButton
+    anchors.right: parent.right
+    anchors.rightMargin: Mycroft.Units.gridUnit / 2
+    height: parent.height - Mycroft.Units.gridUnit / 2
+    width: parent.contentItemWidth
+    anchors.verticalCenter: parent.verticalCenter
+    from: 15
+    to: 60
+    stepSize: 15
+    value: 30
+    snapMode: Slider.SnapAlways
+    
+    property var guiEvent: null
+    property var guiEventData: {}
+
+    handle: Rectangle {
+        x: displaySettingItemSwitchButton.leftPadding + displaySettingItemSwitchButton.visualPosition * (displaySettingItemSwitchButton.availableWidth - width)
+        y: displaySettingItemSwitchButton.topPadding + displaySettingItemSwitchButton.availableHeight / 2 - height / 2
+        implicitWidth: Mycroft.Units.gridUnit * 2
+        implicitHeight: Mycroft.Units.gridUnit * 2
+        radius: 13
+        color: displaySettingItemSwitchButton.pressed ? Kirigami.Theme.highlightColor : Kirigami.Theme.backgroundColor
+        border.color: Kirigami.Theme.textColor
+
+        Text {
+            anchors.centerIn: parent
+            text: displaySettingItemSwitchButton.value
+            color: Kirigami.Theme.textColor
+        }
+    }
+
+    onMoved: {
+        Mycroft.MycroftController.sendRequest(guiEvent, guiEventData)
+    }
+}

--- a/ovos_plugin_common_play/ocp/res/ui/ConfigSliderDelegate.qml
+++ b/ovos_plugin_common_play/ocp/res/ui/ConfigSliderDelegate.qml
@@ -15,7 +15,6 @@ Slider {
     from: 15
     to: 60
     stepSize: 15
-    value: 30
     snapMode: Slider.SnapAlways
     
     property var guiEvent: null

--- a/ovos_plugin_common_play/ocp/res/ui/ConfigSwitchDelegate.qml
+++ b/ovos_plugin_common_play/ocp/res/ui/ConfigSwitchDelegate.qml
@@ -1,0 +1,34 @@
+import QtQuick.Layouts 1.4
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import org.kde.kirigami 2.10 as Kirigami
+import Mycroft 1.0 as Mycroft
+
+
+Button {
+    id: displaySettingItemSwitchButton
+    anchors.right: parent.right
+    anchors.rightMargin: Mycroft.Units.gridUnit / 2
+    height: parent.height - Mycroft.Units.gridUnit / 2
+    width: parent.contentItemWidth
+    anchors.verticalCenter: parent.verticalCenter
+    checkable: true
+
+    property var guiEvent: null
+    property var guiEventData: {}
+
+    Rectangle {
+        id: displaySettingItemSwitchIcon
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.right: parent.right
+        anchors.rightMargin: 8
+        height: Kirigami.Units.iconSizes.small
+        width: Kirigami.Units.iconSizes.small
+        radius: 1000
+        color: displaySettingItemSwitchButton.checked ? "green" : "red"
+    }
+
+    onClicked: {
+        Mycroft.MycroftController.sendRequest(guiEvent, guiEventData)
+    }
+}

--- a/ovos_plugin_common_play/ocp/res/ui/Search.qml
+++ b/ovos_plugin_common_play/ocp/res/ui/Search.qml
@@ -21,18 +21,159 @@ import QtQuick 2.12
 import QtQuick.Controls 2.12
 import org.kde.kirigami 2.10 as Kirigami
 import Mycroft 1.0 as Mycroft
+import QtGraphicalEffects 1.0
 
 Item {
     id: root
     property bool compactMode: height < 600 ? 1 : 0
+    property bool configOverlayOpened: false
 
     Component.onCompleted: {
         txtFld.forceActiveFocus()
     }
 
+    Keys.onEscapePressed: {
+        if (root.configOverlayOpened) {
+            ocpConfigOverlay.close()
+        }
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        enabled: root.configOverlayOpened ? 1 : 0
+        z: 3
+        onClicked: {
+            if (root.configOverlayOpened) {
+                ocpConfigOverlay.close()
+            }
+        }
+    }
+
+    ItemDelegate {
+        id: ocpConfigOverlay
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.margins: Kirigami.Units.gridUnit * 2
+        opacity: root.configOverlayOpened ? 1 : 0
+        visible: root.configOverlayOpened ? 1 : 0
+        enabled: root.configOverlayOpened ? 1 : 0
+        z: 4
+
+        background: Rectangle {
+            color: Kirigami.Theme.backgroundColor
+            radius: Mycroft.Units.gridUnit * 0.5
+            border.width: 1
+            border.color: Qt.darker(Kirigami.Theme.textColor, 1.5)
+        }
+
+        Keys.onEscapePressed: {
+            if (root.configOverlayOpened) {
+                ocpConfigOverlay.close()
+            }
+        }
+
+        function open() {
+            root.configOverlayOpened = true
+        }
+
+        function close() {
+            root.configOverlayOpened = false
+        }
+
+        Behavior on opacity {
+            OpacityAnimator {
+                duration: Kirigami.Units.longDuration
+                easing.type: Easing.InOutQuad
+            }
+        }
+
+        contentItem: ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: Mycroft.Units.gridUnit
+            spacing: Mycroft.Units.gridUnit
+
+            Item {
+                id: headsOverlay
+                Layout.fillWidth: true
+                Layout.preferredHeight: Mycroft.Units.gridUnit * 3
+                
+                Label {
+                    text: "Settings"                    
+                    anchors.left: parent.left
+                    anchors.top: parent.top
+                    anchors.bottom: parent.bottom
+                    anchors.right: headsOverlayCloseButton.left
+                    horizontalAlignment: Text.AlignLeft
+                    verticalAlignment: Text.AlignVCenter
+                    elide: Text.ElideRight                   
+                    wrapMode: Text.WordWrap
+                    color: Kirigami.Theme.textColor
+                    font.pixelSize: parent.height * 0.6
+                }
+
+                Rectangle {
+                    id: headsOverlayCloseButton
+                    anchors.top: parent.top
+                    anchors.bottom: parent.bottom
+                    anchors.right: parent.right
+                    width: Mycroft.Units.gridUnit * 4
+                    color: Kirigami.Theme.highlightColor
+                    radius: Mycroft.Units.gridUnit * 0.5
+
+                    Kirigami.Icon {
+                        id: closeIcon
+                        anchors.centerIn: parent
+                        width: Mycroft.Units.gridUnit * 1.8
+                        height: Mycroft.Units.gridUnit * 1.8
+                        source: "window-close-symbolic"
+
+                        ColorOverlay {
+                            anchors.fill: parent
+                            source: parent
+                            color: Kirigami.Theme.textColor
+                        }
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            ocpConfigOverlay.close()
+                        }
+                    }
+                }
+            }
+
+            Kirigami.Separator {
+                id: sepOverlay
+                Layout.fillWidth: true
+                Layout.preferredHeight: 1
+            }
+
+            ConfigButtonDelegate {
+                id: timeoutConfigButton
+                label: qsTr("Player Timeout")
+                description: qsTr("Player will be automatically hidden after 30 seconds")
+                checked: sessionData.enable_app_view_timeout ? sessionData.enable_app_view_timeout : false
+                switchLabel: timeoutConfigButton.checked ? qsTr("Enabled") : qsTr("Disabled")
+                guiEvent: "ovos.common_play.gui.enable_app_timeout"
+                guiEventData: {"enabled": timeoutConfigButton.checked}
+                switchColor: timeoutConfigButton.checked ? "green" : "red"
+            }
+
+            Item {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+            }
+        }
+    }
+
     ColumnLayout {
         anchors.fill: parent
         spacing: Mycroft.Units.gridUnit * 0.5
+        enabled: !root.configOverlayOpened
+        opacity: !root.configOverlayOpened ? 1 : 0.5
 
         Item {
             id: topAreaSearchPage
@@ -63,6 +204,55 @@ Item {
                     wrapMode: Text.WordWrap
                     color: Kirigami.Theme.textColor
                     font.pixelSize: parent.height * 0.4
+                }
+            }
+
+            Button {
+                id: ocpConfigurationButton
+                anchors.verticalCenter: heads.verticalCenter
+                anchors.left: heads.right
+                anchors.leftMargin: Mycroft.Units.gridUnit * 0.5
+                height: compactMode ? Mycroft.Units.gridUnit * 3.5 :  Mycroft.Units.gridUnit * 4
+                width: Mycroft.Units.gridUnit * 4
+
+                background: Rectangle {
+                    id: ocpConfigurationButtonBackground
+                    color: Kirigami.Theme.backgroundColor
+                    radius: Mycroft.Units.gridUnit * 0.5
+                }
+
+                SequentialAnimation {
+                    id: ocpConfigurationButtonAnim
+
+                    PropertyAnimation {
+                        target: ocpConfigurationButtonBackground
+                        property: "color"
+                        to: Qt.lighter(Kirigami.Theme.backgroundColor, 1.5)
+                        duration: 200
+                    }
+
+                    PropertyAnimation {
+                        target: ocpConfigurationButtonBackground
+                        property: "color"
+                        to: ocpConfigurationButton.activeFocus ? Kirigami.Theme.backgroundColor : Qt.darker(Kirigami.Theme.backgroundColor, 1.5)
+                        duration: 200
+                    }
+                }
+
+                contentItem: Item {
+
+                    Kirigami.Icon {
+                        source: "configure"
+                        width: parent.width * 0.8
+                        height: parent.height * 0.8
+                        anchors.centerIn: parent
+                        color: Kirigami.Theme.textColor
+                    }
+                }
+
+                onClicked: {
+                    ocpConfigurationButtonAnim.restart()
+                    ocpConfigOverlay.open()
                 }
             }
 

--- a/ovos_plugin_common_play/ocp/res/ui/Search.qml
+++ b/ovos_plugin_common_play/ocp/res/ui/Search.qml
@@ -158,7 +158,7 @@ Item {
 
                 ConfigSwitchDelegate {
                     id: timeoutConfigButton
-                    checked: sessionData.enable_app_view_timeout ? sessionData.enable_app_view_timeout : false
+                    checked: sessionData.app_view_timeout_enabled ? sessionData.app_view_timeout_enabled : false
                     text: timeoutConfigButton.checked ? qsTr("Enabled") : qsTr("Disabled")
                     guiEvent: "ovos.common_play.gui.enable_app_timeout"
                     guiEventData: {"enabled": timeoutConfigButton.checked}
@@ -169,11 +169,50 @@ Item {
                 id: setTimeoutConfigDelegateItem
                 label: qsTr("Set Player Timeout")
                 description: qsTr("Timeout for player to be automatically hidden")
+                enabled: timeoutConfigButton.checked
+                opacity: timeoutConfigButton.checked ? 1 : 0.5
 
                 ConfigSliderDelegate {
                     id: configSliderTimeout
+                    value: sessionData.app_view_timeout ? sessionData.app_view_timeout : 30
                     guiEvent: "ovos.common_play.gui.set_app_timeout"
                     guiEventData: {"timeout": configSliderTimeout.value}
+                }
+            }
+
+            ConfigDelegateLayoutItem {
+                id: setTimeoutModeConfigDelegateItem
+                label: qsTr("Select Timeout Mode")
+                description: qsTr("All: Timeout always | Pause: Timeout on pause")
+                enabled: timeoutConfigButton.checked
+                opacity: timeoutConfigButton.checked ? 1 : 0.5
+
+                ConfigOptionDelegate {
+                    id: configTimeoutMode
+                    property string selectedMode: sessionData.app_view_timeout_mode ? sessionData.app_view_timeout_mode : "all"
+                    model: ListModel {
+                        id: model
+                        ListElement { text: "All"; value: "all" }
+                        ListElement { text: "Pause"; value: "pause" }
+                    }
+                    textRole: "text"
+                    valueRole: "value"
+
+                    currentIndex: 0
+                    guiEvent: "ovos.common_play.gui.timeout.mode"
+                    guiEventData: {"mode": model.get(currentIndex).value}
+
+                    onSelectedModeChanged: {
+                        if(selectedMode == "all") {
+                            currentIndex = 0
+                        } else if(selectedMode == "pause") {
+                            currentIndex = 1
+                        }
+                    }
+
+                    onCurrentValueChanged: {
+                        Mycroft.MycroftController.sendRequest(guiEvent, guiEventData)
+                    }
                 }
             }
 
@@ -232,7 +271,7 @@ Item {
 
                 background: Rectangle {
                     id: ocpConfigurationButtonBackground
-                    color: Kirigami.Theme.backgroundColor
+                    color: Qt.darker(Kirigami.Theme.highlightColor, 1.25)
                     radius: Mycroft.Units.gridUnit * 0.5
                 }
 
@@ -242,14 +281,14 @@ Item {
                     PropertyAnimation {
                         target: ocpConfigurationButtonBackground
                         property: "color"
-                        to: Qt.lighter(Kirigami.Theme.backgroundColor, 1.5)
+                        to: Qt.lighter(Kirigami.Theme.highlightColor, 1.25)
                         duration: 200
                     }
 
                     PropertyAnimation {
                         target: ocpConfigurationButtonBackground
                         property: "color"
-                        to: ocpConfigurationButton.activeFocus ? Kirigami.Theme.backgroundColor : Qt.darker(Kirigami.Theme.backgroundColor, 1.5)
+                        to: Qt.darker(Kirigami.Theme.highlightColor, 1.25)
                         duration: 200
                     }
                 }
@@ -323,7 +362,7 @@ Item {
 
                 background: Rectangle {
                     id: answerButtonBackground
-                    color: answerButton.activeFocus ? Kirigami.Theme.highlightColor : Qt.darker(Kirigami.Theme.highlightColor, 1.5)
+                    color: answerButton.activeFocus ? Kirigami.Theme.highlightColor : Qt.darker(Kirigami.Theme.highlightColor, 1.25)
                     radius: Mycroft.Units.gridUnit
                 }
 
@@ -333,14 +372,14 @@ Item {
                     PropertyAnimation {
                         target: answerButtonBackground
                         property: "color"
-                        to: Qt.lighter(Kirigami.Theme.highlightColor, 1.5)
+                        to: Qt.lighter(Kirigami.Theme.highlightColor, 1.25)
                         duration: 200
                     }
 
                     PropertyAnimation {
                         target: answerButtonBackground
                         property: "color"
-                        to: answerButton.activeFocus ? Kirigami.Theme.highlightColor : Qt.darker(Kirigami.Theme.highlightColor, 1.5)
+                        to: answerButton.activeFocus ? Kirigami.Theme.highlightColor : Qt.darker(Kirigami.Theme.highlightColor, 1.25)
                         duration: 200
                     }
                 }

--- a/ovos_plugin_common_play/ocp/res/ui/Search.qml
+++ b/ovos_plugin_common_play/ocp/res/ui/Search.qml
@@ -151,15 +151,30 @@ Item {
                 Layout.preferredHeight: 1
             }
 
-            ConfigButtonDelegate {
-                id: timeoutConfigButton
-                label: qsTr("Player Timeout")
-                description: qsTr("Player will be automatically hidden after 30 seconds")
-                checked: sessionData.enable_app_view_timeout ? sessionData.enable_app_view_timeout : false
-                switchLabel: timeoutConfigButton.checked ? qsTr("Enabled") : qsTr("Disabled")
-                guiEvent: "ovos.common_play.gui.enable_app_timeout"
-                guiEventData: {"enabled": timeoutConfigButton.checked}
-                switchColor: timeoutConfigButton.checked ? "green" : "red"
+            ConfigDelegateLayoutItem {
+                id: enableTimeoutConfigDelegateItem
+                label: qsTr("Enable Player Timeout")
+                description: qsTr("Player will be automatically hidden after ") + configSliderTimeout.value + qsTr(" seconds")
+
+                ConfigSwitchDelegate {
+                    id: timeoutConfigButton
+                    checked: sessionData.enable_app_view_timeout ? sessionData.enable_app_view_timeout : false
+                    text: timeoutConfigButton.checked ? qsTr("Enabled") : qsTr("Disabled")
+                    guiEvent: "ovos.common_play.gui.enable_app_timeout"
+                    guiEventData: {"enabled": timeoutConfigButton.checked}
+                }
+            }
+
+            ConfigDelegateLayoutItem {
+                id: setTimeoutConfigDelegateItem
+                label: qsTr("Set Player Timeout")
+                description: qsTr("Timeout for player to be automatically hidden")
+
+                ConfigSliderDelegate {
+                    id: configSliderTimeout
+                    guiEvent: "ovos.common_play.gui.set_app_timeout"
+                    guiEventData: {"timeout": configSliderTimeout.value}
+                }
             }
 
             Item {


### PR DESCRIPTION
- Adds configuration settings overlay to home (search page)
- Adds config option to timeout Player / Application in 30 seconds to return to home screen from whenever the player page is activated for media playback
