### PR TITLE
Prevent duplicate messagebus events

### DIFF
--- a/ovos_plugin_common_play/ocp/__init__.py
+++ b/ovos_plugin_common_play/ocp/__init__.py
@@ -57,7 +57,15 @@ class OCP(OVOSAbstractApplication):
         self.media_intents = IntentContainer()
         self.register_ocp_api_events()
         self.register_media_intents()
-        self.replace_mycroft_cps()
+
+        self.add_event("mycroft.ready", self.replace_mycroft_cps, once=True)
+        skills_ready = self.bus.wait_for_response(
+            Message("mycroft.skills.is_ready",
+                    context={"source": [self.skill_id],
+                             "destination": ["skills"]}))
+        if skills_ready and skills_ready.data.get("status"):
+            self.remove_event("mycroft.ready")
+            self.replace_mycroft_cps(skills_ready)
         try:
             create_desktop_file()
         except:  # permission errors and stuff

--- a/ovos_plugin_common_play/ocp/__init__.py
+++ b/ovos_plugin_common_play/ocp/__init__.py
@@ -101,7 +101,7 @@ class OCP(OVOSAbstractApplication):
 
             if missing:
                 LOG.info(f"OCP intents missing, registering for {self}")
-                self.register_intent("play.intent", self.handle_play)  # 2x?
+                self.register_intent("play.intent", self.handle_play)
                 self.register_intent("read.intent", self.handle_read)
                 self.register_intent("open.intent", self.handle_open)
                 self.register_intent("next.intent", self.handle_next)

--- a/ovos_plugin_common_play/ocp/__init__.py
+++ b/ovos_plugin_common_play/ocp/__init__.py
@@ -93,7 +93,7 @@ class OCP(OVOSAbstractApplication):
 
             if missing:
                 LOG.info(f"OCP intents missing, registering for {self}")
-                self.register_intent("play.intent", self.handle_play)
+                self.register_intent("play.intent", self.handle_play)  # 2x?
                 self.register_intent("read.intent", self.handle_read)
                 self.register_intent("open.intent", self.handle_open)
                 self.register_intent("next.intent", self.handle_next)
@@ -127,6 +127,12 @@ class OCP(OVOSAbstractApplication):
             self.media_intents.add_intent(intent_name, samples)
 
     def replace_mycroft_cps(self, message=None):
+        """
+        Deactivates any Mycroft playback-control skills and ensures OCP intents
+        are registered. Registers a listener so this method is called any time
+        `mycroft.ready` is emitted.
+        @param message: `mycroft.ready` message triggering this check
+        """
         mycroft_cps_ids = [
             # disable mycroft cps, ocp replaces it and intents conflict
             "skill-playback-control.mycroftai",  # the convention
@@ -150,10 +156,13 @@ class OCP(OVOSAbstractApplication):
                 self.bus.emit(Message('skillmanager.deactivate',
                                       {"skill": skill_id}))
 
-        self.add_event("mycroft.skills.loaded", unload_mycroft_cps)
+        if ("mycroft.skills.loaded", unload_mycroft_cps) not in self.events:
+            self.add_event("mycroft.skills.loaded", unload_mycroft_cps)
 
         # if skills service (re)loads (re)register OCP
-        self.bus.once("mycroft.ready",  self.replace_mycroft_cps)
+        if ("mycroft.ready", self.replace_mycroft_cps) in self.events:
+            LOG.warning("Method already registered!")
+        self.add_event("mycroft.ready",  self.replace_mycroft_cps, once=True)
 
     def default_shutdown(self):
         self.player.shutdown()
@@ -244,7 +253,7 @@ class OCP(OVOSAbstractApplication):
 
     def _do_play(self, phrase, results, media_type=MediaType.GENERIC):
         self.player.reset()
-        LOG.debug(f"Playing results for: {phrase} | {results}")
+        LOG.debug(f"Playing {len(results)} results for: {phrase}")
         if not results:
             if self.gui:
                 if self.gui.active_extension == "smartspeaker":

--- a/ovos_plugin_common_play/ocp/search.py
+++ b/ovos_plugin_common_play/ocp/search.py
@@ -17,7 +17,7 @@ from ovos_utils.messagebus import Message, get_mycroft_bus
 
 class OCPQuery:
     def __init__(self, query, ocp_search=None, media_type=MediaType.GENERIC, bus=None):
-        LOG.debug(f"Created {media_type} query: {query}")
+        LOG.debug(f"Created {media_type.name} query: {query}")
         self.query = query
         self.media_type = media_type
         self.ocp_search = ocp_search
@@ -92,11 +92,11 @@ class OCPQuery:
     def register_events(self):
         LOG.debug("Registering Search Bus Events")
         self.bus.on("ovos.common_play.skill.search_start",
-                    self.handle_skill_search_start)  # 4x
+                    self.handle_skill_search_start)
         self.bus.on("ovos.common_play.skill.search_end",
-                    self.handle_skill_search_end)  # 4x
+                    self.handle_skill_search_end)
         self.bus.on("ovos.common_play.query.response",
-                    self.handle_skill_response)  # 8x
+                    self.handle_skill_response)
 
     def remove_events(self):
         LOG.debug("Removing Search Bus Events")

--- a/ovos_plugin_common_play/ocp/search.py
+++ b/ovos_plugin_common_play/ocp/search.py
@@ -1,4 +1,6 @@
 import random
+from threading import RLock
+
 import time
 
 from ovos_plugin_common_play.ocp.base import OCPAbstractComponent
@@ -15,6 +17,7 @@ from ovos_utils.messagebus import Message, get_mycroft_bus
 
 class OCPQuery:
     def __init__(self, query, ocp_search=None, media_type=MediaType.GENERIC, bus=None):
+        LOG.debug(f"Created {media_type} query: {query}")
         self.query = query
         self.media_type = media_type
         self.ocp_search = ocp_search
@@ -87,14 +90,16 @@ class OCPQuery:
         return [s for s in self.query_replies if s.get("results")]
 
     def register_events(self):
+        LOG.debug("Registering Search Bus Events")
         self.bus.on("ovos.common_play.skill.search_start",
-                                  self.handle_skill_search_start)
+                    self.handle_skill_search_start)  # 4x
         self.bus.on("ovos.common_play.skill.search_end",
-                                  self.handle_skill_search_end)
+                    self.handle_skill_search_end)  # 4x
         self.bus.on("ovos.common_play.query.response",
-                                  self.handle_skill_response)
+                    self.handle_skill_response)  # 8x
 
     def remove_events(self):
+        LOG.debug("Removing Search Bus Events")
         self.bus.remove_all_listeners("ovos.common_play.skill.search_start")
         self.bus.remove_all_listeners("ovos.common_play.skill.search_end")
         self.bus.remove_all_listeners("ovos.common_play.query.response")
@@ -277,6 +282,7 @@ class OCPSearch(OCPAbstractComponent):
         self.old_cps = None
         self.ocp_skills = {}
         self.featured_skills = {}
+        self.search_lock = RLock()
         if player:
             self.bind(player)
 
@@ -334,41 +340,43 @@ class OCPSearch(OCPAbstractComponent):
                 MediaType.HENTAI not in s["media_type"]]
 
     def search(self, phrase, media_type=MediaType.GENERIC):
-        # stop any search still happening
-        self.bus.emit(Message("ovos.common_play.search.stop"))
-        if self.gui:
-            if self.gui.active_extension == "smartspeaker":
-                self.gui.display_notification("Searching...Your query is being processed")
-            else:
-                if self.gui.persist_home_display:
-                    self.gui.show_search_spinner(persist_home=True)
+        with self.search_lock:
+            # stop any search still happening
+            self.bus.emit(Message("ovos.common_play.search.stop"))
+            if self.gui:
+                if self.gui.active_extension == "smartspeaker":
+                    self.gui.display_notification("Searching...Your query is being processed")
                 else:
-                    self.gui.show_search_spinner(persist_home=False)
-        self.clear()
+                    if self.gui.persist_home_display:
+                        self.gui.show_search_spinner(persist_home=True)
+                    else:
+                        self.gui.show_search_spinner(persist_home=False)
+            self.clear()
 
-        query = OCPQuery(query=phrase, media_type=media_type, ocp_search=self)
-        query.send()
-
-        # old common play will send the messages expected by the official
-        # mycroft stack, but skills are known to over match, dont support
-        # match type, and the GUI can be different for every skill, it may also
-        # cause issues with status tracking and mess up playlists. An
-        # imperfect compatibility layer has been implemented at skill and
-        # audioservice level
-        if self.old_cps:
-            self.old_cps.send_query(phrase, media_type)
-
-        query.wait()
-
-        # fallback to generic search type
-        if not query.results and \
-                self.settings.search_fallback and \
-                media_type != MediaType.GENERIC:
-            LOG.debug("OVOSCommonPlay falling back to MediaType.GENERIC")
-            query.media_type = MediaType.GENERIC
-            query.reset()
+            query = OCPQuery(query=phrase, media_type=media_type, ocp_search=self,
+                             bus=self.bus)
             query.send()
+
+            # old common play will send the messages expected by the official
+            # mycroft stack, but skills are known to over match, dont support
+            # match type, and the GUI can be different for every skill, it may also
+            # cause issues with status tracking and mess up playlists. An
+            # imperfect compatibility layer has been implemented at skill and
+            # audioservice level
+            if self.old_cps:
+                self.old_cps.send_query(phrase, media_type)
+
             query.wait()
+
+            # fallback to generic search type
+            if not query.results and \
+                    self.settings.search_fallback and \
+                    media_type != MediaType.GENERIC:
+                LOG.debug("OVOSCommonPlay falling back to MediaType.GENERIC")
+                query.media_type = MediaType.GENERIC
+                query.reset()
+                query.send()
+                query.wait()
 
         if self.gui:
             self.gui.update_search_results()

--- a/test/unittests/test_mycroft.py
+++ b/test/unittests/test_mycroft.py
@@ -3,6 +3,8 @@ import unittest
 from os.path import dirname, join
 from unittest.mock import patch
 
+from mycroft_bus_client import Message
+
 from mycroft.configuration.config import Configuration
 from mycroft.skills.intent_service import IntentService
 from mycroft.skills.skill_loader import SkillLoader
@@ -122,7 +124,7 @@ class TestCPS(unittest.TestCase):
         self.bus.emitted_msgs = []
         cfg = {}
         ocp = OCPAudioBackend(cfg, self.bus)
-
+        self.bus.emit(Message("mycroft.ready"))
         # assert that mycroft common play was deregistered
         disable_msgs = [
             {'type': 'skillmanager.deactivate',


### PR DESCRIPTION
Prevent multiple calls to `replace_mycroft_cps` under normal curcumstances
Add checks to prevent re-registering duplicate messagebus handlers
Update logging and docstrings
Add locking around searches to prevent registering duplicated handlers