### PR TITLE
fix/extractor_error

### DIFF
--- a/ovos_plugin_common_play/ocp/media.py
+++ b/ovos_plugin_common_play/ocp/media.py
@@ -40,6 +40,7 @@ class MediaEntry:
         skipkeys = skipkeys or []
         if isinstance(entry, MediaEntry):
             entry = entry.as_dict
+        entry = entry or {}
         for k, v in entry.items():
             if k not in skipkeys and hasattr(self, k):
                 if newonly and self.__getattribute__(k):
@@ -321,7 +322,8 @@ class NowPlaying(MediaEntry):
             video = False
         meta = ocp_plugins.extract_stream(uri, video)
         # update media entry with new data
-        self.update(meta, newonly=True)
+        if meta:
+            self.update(meta, newonly=True)
 
     # events from gui_player/audio_service
     def handle_external_play(self, message):


### PR DESCRIPTION
extractor may return None and cause this issue, introduced by #27 

```
File "/home/mycroft/.local/lib/python3.10/site-packages/ovos_plugin_common_play/ocp/player.py", line 239, in validate_stream
    self.now_playing.extract_stream()
  File "/home/mycroft/.local/lib/python3.10/site-packages/ovos_plugin_common_play/ocp/media.py", line 324, in extract_stream
    self.update(meta, newonly=True)
  File "/home/mycroft/.local/lib/python3.10/site-packages/ovos_plugin_common_play/ocp/media.py", line 306, in update
    super().update(entry, skipkeys, newonly)
  File "/home/mycroft/.local/lib/python3.10/site-packages/ovos_plugin_common_play/ocp/media.py", line 43, in update
    for k, v in entry.items():
AttributeError: 'NoneType' object has no attribute 'items'
```