### PR TITLE
Allow `PlaybackType.SKILL` search results to be played when there is no GUI

### DIFF
--- a/ovos_plugin_common_play/ocp/__init__.py
+++ b/ovos_plugin_common_play/ocp/__init__.py
@@ -378,7 +378,7 @@ class OCP(OVOSAbstractApplication):
             LOG.info("unable to use GUI, filtering non-audio results")
             # filter video only streams
             results = [r for r in results
-                       if r["playback"] == PlaybackType.AUDIO]
+                       if r["playback"] in [PlaybackType.AUDIO, PlaybackType.SKILL]]
         LOG.debug(f"Returning {len(results)} results")
         return results
 


### PR DESCRIPTION
As described in #92, this commit permits search results of `PlaybackType.SKILL` to be played when there is no GUI. The skill handles playback itself and may not need a GUI.

fixes #92