### PR TITLE
fix/OCP_plugins_loading

### DIFF
--- a/ovos_plugin_common_play/ocp/__init__.py
+++ b/ovos_plugin_common_play/ocp/__init__.py
@@ -12,6 +12,7 @@ from ovos_bus_client.message import Message
 from ovos_workshop import OVOSAbstractApplication
 from padacioso import IntentContainer
 from threading import Event, Lock
+from ovos_plugin_common_play.ocp.utils import ocp_plugins
 
 
 class OCP(OVOSAbstractApplication):
@@ -75,6 +76,7 @@ class OCP(OVOSAbstractApplication):
             create_desktop_file()
         except:  # permission errors and stuff
             pass
+        ocp_plugins()  # trigger a load + caching of OCP plugins
 
     def handle_ping(self, message):
         """

--- a/ovos_plugin_common_play/ocp/media.py
+++ b/ovos_plugin_common_play/ocp/media.py
@@ -455,7 +455,7 @@ class NowPlaying(MediaEntry):
             video = True
         else:
             video = False
-        meta = ocp_plugins.extract_stream(uri, video)
+        meta = ocp_plugins().extract_stream(uri, video)
         # update media entry with new data
         if meta:
             LOG.info(f"OCP plugins metadata: {meta}")

--- a/ovos_plugin_common_play/ocp/utils.py
+++ b/ovos_plugin_common_play/ocp/utils.py
@@ -12,7 +12,6 @@ from ovos_ocp_files_plugin.plugin import OCPFilesMetadataExtractor
 _plugins = None
 
 
-@module_property
 def _ocp_plugins():
     global _plugins
     _plugins = _plugins or StreamHandler()

--- a/ovos_plugin_common_play/ocp/utils.py
+++ b/ovos_plugin_common_play/ocp/utils.py
@@ -3,7 +3,6 @@ import shutil
 from os import makedirs
 from os.path import expanduser, isfile, join, dirname, exists
 from typing import List
-from ovos_utils.system import module_property
 
 from ovos_plugin_manager.ocp import StreamHandler
 from ovos_plugin_common_play.ocp.status import TrackState, PlaybackType
@@ -12,7 +11,7 @@ from ovos_ocp_files_plugin.plugin import OCPFilesMetadataExtractor
 _plugins = None
 
 
-def _ocp_plugins():
+def ocp_plugins():
     global _plugins
     _plugins = _plugins or StreamHandler()
     return _plugins
@@ -40,7 +39,7 @@ def available_extractors() -> List[str]:
     @return: List of supported SEI prefixes
     """
     return ["/", "http:", "https:", "file:"] + \
-           [f"{sei}//" for sei in _ocp_plugins().supported_seis]
+           [f"{sei}//" for sei in ocp_plugins().supported_seis]
 
 
 def extract_metadata(uri):

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -2,10 +2,6 @@ import unittest
 
 
 class TestUtils(unittest.TestCase):
-    def test_plugins_init(self):
-        from ovos_plugin_common_play.ocp.utils import ocp_plugins
-        from ovos_plugin_manager.ocp import StreamHandler
-        self.assertIsInstance(ocp_plugins, StreamHandler)
 
     def test_available_extractors(self):
         from ovos_plugin_common_play.ocp.utils import available_extractors


### PR DESCRIPTION
OCP plugins load in every service (eg, core)  even when not used, this is because they are a module property

this makes them ONLY load in OCP, instead of everytime OCP is imported