### PR TITLE
Update dependencies to stable versions with ovos-core 0.0.7 compat.

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
-ovos-plugin-manager >= 0.0.25a4, < 0.1.0
+ovos-plugin-manager >= 0.0.25, < 0.1.0
 ovos-bus-client>=0.0.7, < 0.1.0
 ovos-utils>=0.0.38, < 0.1.0
-ovos_workshop >=0.0.15a2, < 0.1.0
+ovos_workshop >=0.0.15, < 0.1.0
 ovos-ocp-files-plugin~=0.13
-padacioso~=0.2, >=0.1.1
+padacioso~=0.1, >=0.1.1
 dbus-next


### PR DESCRIPTION
Loosen padacioso dependency for ovos-core compat.
Update dependencies to stable versions\

Dependency resolution tested https://github.com/NeonGeckoCom/NeonCore/pull/600