### PR TITLE
Add upper version pin for ovos-utils

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 ovos-plugin-manager >= 0.0.25, < 0.1.0
 ovos-bus-client>=0.0.7, < 0.1.0
-ovos-utils>=0.0.38
+ovos-utils>=0.0.38,<1.0.0
 ovos_workshop >=0.0.15, < 0.1.0
 ovos-ocp-files-plugin~=0.13
 padacioso~=0.1, >=0.1.1


### PR DESCRIPTION
Allows for compat with ovos-utils 0.x as deprecated references have been removed