### PR TITLE
fix/playlist_handling

### DIFF
--- a/ovos_plugin_common_play/ocp/media.py
+++ b/ovos_plugin_common_play/ocp/media.py
@@ -194,7 +194,7 @@ class NowPlaying(MediaEntry):
 
     def extract_stream(self):
         """
-        Get metadata from ocp_plugins and add it to this MediaEntry
+        DEPRECATED: Get metadata from ocp_plugins and add it to this MediaEntry
         """
         uri = self.uri
         if not uri:

--- a/ovos_plugin_common_play/ocp/player.py
+++ b/ovos_plugin_common_play/ocp/player.py
@@ -261,7 +261,8 @@ class OCPMediaPlayer(OVOSAbstractApplication):
         if isinstance(track, PluginStream):
             track = track.extract_media_entry(video=track.playback == PlaybackType.VIDEO)
             LOG.info(f"PluginStream extracted: {track}")
-            self.playlist[idx] = track  # update extracted plugin stream
+            if idx >= 0:
+                self.playlist[idx] = track  # update extracted plugin stream
 
         if isinstance(track, MediaEntry):
             # single track entry (MediaEntry)

--- a/ovos_plugin_common_play/ocp/player.py
+++ b/ovos_plugin_common_play/ocp/player.py
@@ -261,7 +261,7 @@ class OCPMediaPlayer(OVOSAbstractApplication):
         if isinstance(track, PluginStream):
             track = track.extract_media_entry(video=track.playback == PlaybackType.VIDEO)
             LOG.info(f"PluginStream extracted: {track}")
-            self.playlist[idx] = track # update extracted plugin stream
+            self.playlist[idx] = track  # update extracted plugin stream
 
         if isinstance(track, MediaEntry):
             # single track entry (MediaEntry)
@@ -316,11 +316,6 @@ class OCPMediaPlayer(OVOSAbstractApplication):
         if self.active_backend not in [PlaybackType.SKILL,
                                        PlaybackType.UNDEFINED,
                                        PlaybackType.MPRIS]:
-            try:
-                self.now_playing.extract_stream()
-            except Exception as e:
-                LOG.exception(e)
-                return False
             has_gui = is_gui_running() or is_gui_connected(self.bus)
             if not has_gui or self.settings.get("force_audioservice", False) or \
                     self.settings.get("playback_mode") == PlaybackMode.FORCE_AUDIOSERVICE:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 ovos-plugin-manager >=0.0.26a5, < 0.1.0
 ovos-bus-client>=0.0.7, < 0.1.0
 ovos-utils>=0.0.38, < 1.0.0
-ovos-workshop>=0.0.16a39, < 0.1.0
+ovos-workshop>=0.0.16a48, < 0.1.0
 padacioso~=0.1, >=0.1.1
 dbus-next

--- a/test/unittests/test_audio_backends.py
+++ b/test/unittests/test_audio_backends.py
@@ -51,26 +51,6 @@ class TestOCPLoad(unittest.TestCase):
 
         self.audio = AudioService(self.bus)
 
-    def test_native_ocp(self):
-        # assert that OCP is the selected default backend
-        self.assertTrue(isinstance(self.audio.default, OCPAudioBackend))
-
-        # assert that OCP is in "auto" mode
-        self.assertEqual(self.audio.default.config["mode"], "auto")
-
-        # assert that OCP is loaded
-        self.assertTrue(self.audio.default.ocp is not None)
-        self.assertTrue(isinstance(self.audio.default.ocp, OCP))
-
-        # assert that test backends also loaded
-        # NOTE: "service" is a list, should be named "services"
-        # not renamed for backwards compat but its a typo!
-        loaded_services = [s.name for s in self.audio.service]
-        self.assertIn("OCP", loaded_services)
-        # TODO fix me, add dummy plugins
-        #self.assertIn("mycroft_test", loaded_services)
-        #self.assertIn("ovos_test", loaded_services)
-
     def tearDown(self) -> None:
         self.audio.shutdown()
 

--- a/test/unittests/test_external_ocp.py
+++ b/test/unittests/test_external_ocp.py
@@ -47,17 +47,6 @@ class TestExternalOCP(unittest.TestCase):
 
         cls.bus.on("message", get_msg)
 
-    @patch.object(Configuration, 'load_all_configs')
-    def test_external_ocp(self, mock):
-        mock.return_value = BASE_CONF
-        audio = AudioService(self.bus)
-        self.assertEqual(audio.config, BASE_CONF["Audio"])
-        # assert that ocp is in external mode
-        self.assertEqual(audio.default.config["mode"], "external")
-        # assert that OCP is not loaded
-        self.assertTrue(audio.default.ocp is None)
-        audio.shutdown()
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unittests/test_ocp_player.py
+++ b/test/unittests/test_ocp_player.py
@@ -215,12 +215,10 @@ class TestOCPPlayer(unittest.TestCase):
         real_update_props = self.player.mpris.update_props
         real_update_track = self.player.gui.update_current_track
         real_update_plist = self.player.gui.update_playlist
-        real_nowplaying_reset = self.player.now_playing.reset
 
         self.player.mpris.update_props = Mock()
         self.player.gui.update_current_track = Mock()
         self.player.gui.update_playlist = Mock()
-        self.player.now_playing.reset = Mock()
 
         valid_dict = valid_search_results[0]
         valid_track = MediaEntry.from_dict(valid_search_results[1])
@@ -241,8 +239,6 @@ class TestOCPPlayer(unittest.TestCase):
         self.player.mpris.update_props.assert_called_once_with(
             {"Metadata": self.player.now_playing.mpris_metadata}
         )
-        self.player.now_playing.reset.assert_called_once()
-        self.player.now_playing.reset.reset_mock()
         self.player.gui.update_current_track.reset_mock()
         self.player.gui.update_playlist.reset_mock()
         self.player.mpris.update_props.reset_mock()
@@ -256,8 +252,6 @@ class TestOCPPlayer(unittest.TestCase):
         self.player.gui.update_playlist.assert_called_once()
         self.player.mpris.update_props.assert_called_once_with(
             {"Metadata": self.player.now_playing.mpris_metadata})
-        self.player.now_playing.reset.assert_called_once()
-        self.player.now_playing.reset.reset_mock()
         self.player.gui.update_current_track.reset_mock()
         self.player.gui.update_playlist.reset_mock()
         self.player.mpris.update_props.reset_mock()
@@ -265,7 +259,6 @@ class TestOCPPlayer(unittest.TestCase):
         # Play invalid string result
         with self.assertRaises(ValueError):
             self.player.set_now_playing(invalid_str)
-        self.player.now_playing.reset.assert_not_called()
         self.player.gui.update_current_track.assert_not_called()
         self.player.gui.update_playlist.assert_not_called()
         self.player.mpris.update_props.assert_not_called()
@@ -276,12 +269,10 @@ class TestOCPPlayer(unittest.TestCase):
         self.player.gui.update_playlist.assert_called_once()
         self.player.mpris.update_props.assert_called_once_with(
             {"Metadata": self.player.now_playing.mpris_metadata})
-        self.player.now_playing.reset.assert_called_once()
 
         self.player.mpris.update_props = real_update_props
         self.player.gui.update_current_track = real_update_track
         self.player.gui.update_playlist = real_update_plist
-        self.player.now_playing.reset = real_nowplaying_reset
 
     @patch("ovos_plugin_common_play.ocp.player.is_gui_running")
     def test_validate_stream(self, gui_running):
@@ -423,7 +414,7 @@ class TestOCPPlayer(unittest.TestCase):
         preferred = self.player._get_preferred_audio_backend()
         self.assertIsInstance(preferred, str)
         self.assertIn(preferred,
-                      ["ovos_common_play", "vlc", "mplayer", "simple"])
+                      ["mpv", "ovos_common_play", "vlc", "mplayer", "simple"])
 
     @patch("ovos_plugin_common_play.ocp.player.is_gui_running")
     def test_play(self, gui_running):


### PR DESCRIPTION
fix position of "now playing" handling

fix PluginStream to MediaEntry extraction

fix Playlist of PluginStream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated track management for improved handling of playlists and currently playing tracks.
  - Introduced default URI assignment for better synchronization from MPRIS.

- **Deprecation Notices**
  - Added a deprecation notice for the `extract_stream` method to inform users of its phasing out.

- **Bug Fixes**
  - Enhanced error handling and logic in the `validate_stream` method.

- **Tests**
  - Removed outdated test methods to streamline testing coverage and focus on essential behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->