### PR TITLE
logs/end_of_track

### DIFF
--- a/ovos_plugin_common_play/ocp/player.py
+++ b/ovos_plugin_common_play/ocp/player.py
@@ -769,10 +769,14 @@ class OCPMediaPlayer(OVOSAbstractApplication):
     @require_native_source()
     def handle_playback_ended(self, message):
         # TODO: When we get here, self.active_backend has been reset!
-        if (self.settings.get("autoplay", True) and \
-                self.active_backend != PlaybackType.MPRIS and
-                len(self.playlist.entries)):
-            LOG.debug(f"Playing next (backend={repr(self.active_backend)}")
+        LOG.info(f"END OF MEDIA - playlist pos: {self.playlist.position} "
+                  f"total tracks: {len(self.playlist)} "
+                 f"backend: {self.active_backend}")
+        go_next = self.settings.get("autoplay", True) and \
+                self.active_backend != PlaybackType.MPRIS and \
+                self.playlist.position + 1 < len(self.playlist)
+        LOG.debug(f"Go to Next track: {go_next}")
+        if go_next:
             self.play_next()
             return
         LOG.info("Playback ended")


### PR DESCRIPTION
make it easier to debug issues like  https://github.com/OpenVoiceOS/ovos-ocp-audio-plugin/issues/123

companion to https://github.com/OpenVoiceOS/ovos-audio-plugin-mpv/pull/6

```
2024-08-06 19:18:19.439 - audio - ovos_plugin_mpv:handle_track_end:54 - DEBUG - MPV playback start
2024-08-06 19:18:19.444 - audio - ovos_audio.audio:track_start:212 - DEBUG - New track coming up!
2024-08-06 19:18:19.505 - audio - ovos_plugin_common_play.ocp.player:handle_player_media_update:744 - DEBUG - backend=<PlaybackType.AUDIO_SERVICE: 3>|msg_type=ovos.common_play.media.state
2024-08-06 19:23:53.679 - audio - ovos_plugin_mpv:handle_track_end:58 - DEBUG - MPV playback ended
2024-08-06 19:23:53.683 - audio - ovos_audio.audio:track_start:219 - DEBUG - End of playlist!
2024-08-06 19:23:53.701 - audio - ovos_plugin_common_play.ocp.player:handle_player_media_update:744 - DEBUG - backend=<PlaybackType.AUDIO_SERVICE: 3>|msg_type=ovos.common_play.media.state
2024-08-06 19:23:53.702 - audio - ovos_plugin_common_play.ocp.player:handle_player_state_update:717 - INFO - PlayerState changed: <PlayerState.STOPPED: 0>
2024-08-06 19:23:53.703 - audio - ovos_plugin_common_play.ocp.player:handle_player_media_update:756 - DEBUG - MediaState changed: <MediaState.END_OF_MEDIA: 7>
2024-08-06 19:23:53.705 - audio - ovos_plugin_common_play.ocp.player:handle_playback_ended:772 - INFO - END OF MEDIA - playlist pos: 0 total tracks: 9 backend: 3
2024-08-06 19:23:53.707 - audio - ovos_plugin_common_play.ocp.player:handle_playback_ended:778 - DEBUG - Go to Next track: True
2024-08-06 19:23:53.709 - audio - ovos_plugin_common_play.ocp.player:pause:578 - DEBUG - Pausing playback: 3
2024-08-06 19:23:53.716 - audio - ovos_plugin_common_play.ocp.player:set_now_playing:251 - DEBUG - Playing: PluginStream(stream='https://music.youtube.com/watch?v=YXM1W0LOT8o', extractor_id='youtube', title='Rastejantes', artist='Xeque Mate', match_confidence=83.91304347826087, skill_id='skill-ovos-youtube-music.openvoiceos', playback=2, status=1, media_type=2, length=317000, image=None, skill_icon='/home/miro/PycharmProjects/ovos-core/.venv/lib/python3.11/site-packages/skill_ovos_youtube_music/res/ytmus.png')
2024-08-06 19:23:58.615 - audio - ovos_plugin_common_play.ocp.player:set_now_playing:266 - INFO - PluginStream extracted: MediaEntry(uri='https://rr1---sn-ovn-v2v6.googlevideo.com/videoplayback?expire=1722990234&ei=OmqyZv_3LtbVp-oPseKF8Ak&ip=89.154.90.167&id=o-AIfkRAsWehJXo-yQSusPnyzUtHiFg61eZ1hNqNwg5xm0&itag=251&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&mh=Z7&mm=31%2C29&mn=sn-ovn-v2v6%2Csn-ovn-apnk&ms=au%2Crdu&mv=m&mvi=1&pl=20&gcr=pt&initcwndbps=1532500&bui=AXc671JihEiQHw4HuhH6aPllsuXFFpYJ1h_7gBSo25fZp9zMiO_tU3yw_OCV9QbiqIT6tG52QTaXl9wy&spc=Mv1m9jQqYd7hJ8d1NWsgniMP3GAfAlcQsNfDjVO870bA6_gDt-ay&vprv=1&svpuc=1&mime=audio%2Fwebm&ns=X-jcX5upR0TtQKX38aGhUn4Q&rqh=1&gir=yes&clen=5279568&dur=316.461&lmt=1714684464124773&mt=1722968245&fvip=2&keepalive=yes&c=WEB_CREATOR&sefc=1&txp=2318224&n=iRn54Oq0NY3KNg&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Cns%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&lsparams=mh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Cinitcwndbps&lsig=AGtxev0wRAIfBRxPhYQrUQUSz40NggXQm45NOKgJfgg4wNWtgsUuoQIhANWmhHMAcBWAHkqS4pLJMpBouMmHvgUKJw_OcyYXJHqy&sig=AJfQdSswRgIhAMA86ns1DbqraccylWH9aXtxWuCGA9uvgkO1r_paIAT7AiEAuxcA3bJx4FyQsmFNhnKj09PrSBrKAbS4-0o0ltfSUL0%3D', title='Rastejantes', artist='Xeque Mate - Topic', match_confidence=83.91304347826087, skill_id='skill-ovos-youtube-music.openvoiceos', playback=2, status=1, media_type=2, length=317000, image='https://i.ytimg.com/vi_webp/YXM1W0LOT8o/maxresdefault.webp', skill_icon='/home/miro/PycharmProjects/ovos-core/.venv/lib/python3.11/site-packages/skill_ovos_youtube_music/res/ytmus.png', javascript='')
2024-08-06 19:23:58.619 - audio - ovos_plugin_common_play.ocp.player:play_next:528 - INFO - Next track index: 1
2024-08-06 19:24:01.768 - audio - ovos_plugin_common_play.ocp.player:validate_stream:327 - DEBUG - Casting to PlaybackType.AUDIO_SERVICE

```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging for media playback state at the end of playback, providing detailed insights into the playlist and backend.
	- Improved logic to ensure the next track exists before attempting to play it, enhancing playback robustness.

- **Bug Fixes**
	- Refined conditions for autoplay and playlist management to prevent errors related to out-of-bounds access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->