### PR TITLE
feat:ovos.common_play.search.populate event

### DIFF
--- a/ovos_plugin_common_play/ocp/gui.py
+++ b/ovos_plugin_common_play/ocp/gui.py
@@ -1,7 +1,6 @@
 import enum
 import time
 from os.path import join, dirname
-from threading import Timer
 from time import sleep
 
 from ovos_bus_client.apis.gui import GUIInterface
@@ -33,7 +32,6 @@ class OCPMediaPlayerGUI(GUIInterface):
                                                 ui_directories=ui_dirs,
                                                 config=gui_config)
         self.ocp_skills = {}  # skill_id: meta
-        self.active_extension = gui_config.get("extension", "generic")
         self.search_mode_is_app = False
         self.persist_home_display = False
         self.event_scheduler_interface = None
@@ -41,16 +39,11 @@ class OCPMediaPlayerGUI(GUIInterface):
     def bind(self, player):
         self.player = player
         super().set_bus(self.bus)
-        self.player.add_event("ovos.common_play.playback_time",
-                              self.handle_sync_seekbar)
-        self.player.add_event('ovos.common_play.playlist.play',
-                              self.handle_play_from_playlist)
-        self.player.add_event('ovos.common_play.search.play',
-                              self.handle_play_from_search)
-        self.player.add_event('ovos.common_play.skill.play',
-                              self.handle_play_skill_featured_media)
-        self.event_scheduler_interface = \
-            EventSchedulerInterface(skill_id=OCP_ID, bus=self.bus)
+        self.player.add_event("ovos.common_play.playback_time", self.handle_sync_seekbar)
+        self.player.add_event('ovos.common_play.playlist.play', self.handle_play_from_playlist)
+        self.player.add_event('ovos.common_play.search.play', self.handle_play_from_search)
+        self.player.add_event('ovos.common_play.skill.play', self.handle_play_skill_featured_media)
+        self.event_scheduler_interface = EventSchedulerInterface(skill_id=OCP_ID, bus=self.bus)
 
     @property
     def video_backend(self):

--- a/ovos_plugin_common_play/ocp/search.py
+++ b/ovos_plugin_common_play/ocp/search.py
@@ -72,14 +72,3 @@ class OCPSearch(OCPAbstractComponent):
         return [s for s in skills
                 if MediaType.ADULT not in s["media_type"] and
                 MediaType.HENTAI not in s["media_type"]]
-
-    def clear(self):
-        self.search_playlist.clear()
-        if self.gui:
-            self.gui.update_search_results()
-
-    def replace(self, playlist):
-        self.search_playlist.clear()
-        self.search_playlist.replace(playlist)
-        if self.gui:
-            self.gui.update_search_results()


### PR DESCRIPTION
new bus event to allow replacing the search results explicitly, meant for usage by ocp pipeline

remove more dead code

companion to https://github.com/OpenVoiceOS/ovos-bus-client/pull/118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new event handler for managing search results in the playlist, allowing for dynamic updates based on user actions.
- **Bug Fixes**
	- Improved handling of media states during resets by specifically targeting the search playlist.
	- Streamlined playback request handling for enhanced clarity and reduced errors.
- **Refactor**
	- Removed unused methods related to playlist management, indicating a shift towards a more streamlined approach. 
- **Chores**
	- Cleaned up code formatting and organization to enhance readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->