### PR TITLE
fix:cache_gui_files

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 ovos-plugin-manager>=0.0.26,<1.0.0
-ovos_bus_client>=0.0.7,<1.0.0
+ovos_bus_client>=0.0.7,<2.0.0
 ovos-utils>=0.0.38,<1.0.0
 ovos-workshop>=0.0.16,<1.0.0
 padacioso~=0.1, >=0.1.1


### PR DESCRIPTION
companion to OpenVoiceOS/ovos-gui#53 and OpenVoiceOS/ovos-bus-client#120

this should be merged first as it does not require the others to work and does not break anything in the wild

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced integration of the media player interface with the skill framework for improved functionality.
	- Introduced a mock skill implementation to streamline the setup process.

- **Bug Fixes**
	- Updated dependency constraints to ensure compatibility with newer versions of the `ovos_bus_client`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->