### PR TITLE
fix:workshop2_compat

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 ovos-plugin-manager>=0.0.26,<1.0.0
 ovos_bus_client>=0.0.7,<1.0.0
 ovos-utils>=0.1.0,<1.0.0
-ovos-workshop>=0.0.16,<2.0.0
+ovos-workshop>=0.0.16,<3.0.0
 padacioso>=0.1.1,<2.0.0
 dbus-next


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated version constraint for the `ovos-workshop` package to allow for newer versions below 3.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->