### PR TITLE
test: fix media-intent assertions under the bus-client 2.x stack (padacioso 1.x)

### DIFF
--- a/test/unittests/test_media_intents.py
+++ b/test/unittests/test_media_intents.py
@@ -63,7 +63,9 @@ class TestEnglishMediaIntents(unittest.TestCase):
 
         intent = self.media_intents.calc_intent("play some music")
         self.assertEqual(intent['name'], 'music')
-        self.assertEqual(intent['entities'], {'query': 'some'})
+        # "some" is a filler matched by the literal "(some|a) (music|song)"
+        # rule, so no query entity is extracted
+        self.assertEqual(intent['entities'], {})
         self.assertGreaterEqual(intent['conf'], 0.9)
 
     def test_movie(self):
@@ -74,7 +76,9 @@ class TestEnglishMediaIntents(unittest.TestCase):
 
         intent = self.media_intents.calc_intent("play a movie")
         self.assertEqual(intent['name'], 'movie')
-        self.assertEqual(intent['entities'], {'query': 'a'})
+        # "a movie" is matched by the literal "(a movie|movie|...)" rule,
+        # so no query entity is extracted
+        self.assertEqual(intent['entities'], {})
         self.assertGreaterEqual(intent['conf'], 0.9)
 
         intent = self.media_intents.calc_intent("play the matrix movie")


### PR DESCRIPTION
## Why

Refs #194. The `ovos-bus-client<2.0.0` cap that originally blocked the bus-client 2.x stack (hivemind-core 4.6.x) was already relaxed to `<3.0.0` on `dev` (PR #192) and is published in the `1.3.3a1` alpha. This PR closes the remaining gap: when OCP is installed against the 2.x stack, the test suite was **failing** (so a clean stable release was blocked).

## What

When OCP is installed against `ovos-bus-client 2.x`, the resolver pulls in `padacioso 1.x`. padacioso 1.x's intent matcher now prefers dedicated literal rules over greedy `{query}` capture, so:

- `"play a movie"` matches `(play|start) (a movie|movie|movies|film|films)` -> no `query` entity (was `{'query': 'a'}`)
- `"play some music"` matches `(play|start) (some|a) (music|song)` -> no `query` entity (was `{'query': 'some'}`)

This is the more correct parse (these are filler words, not titles). The two assertions in `test/unittests/test_media_intents.py` are updated accordingly.

## No source migration required

Every `ovos_bus_client` import used by OCP resolves on 2.x (`Message`, `dig_for_message`, `MessageBusClient`, `SessionManager`, `apis.ocp.ClassicAudioServiceInterface`, `apis.gui.GUIInterface`). No production code changes were needed.

## Verification

Installed `-e .[test]` with `UV_PRERELEASE=allow` (Python 3.11):
- `ovos-bus-client 2.1.2a1`, `padacioso 1.1.1a1`, `ovos-workshop 8.2.1a1`, `ovos-utils 0.11.2a1`
- Full suite: **95 passed**

**Coexistence proof** -- fresh venv, `uv pip install <local OCP> "hivemind-core>=4.6.2a1"` resolves (no ResolutionImpossible):
- `ovos-plugin-common-play 1.3.3a1`
- `hivemind-core 4.6.5a1`
- `ovos-bus-client 2.1.2a1` (shared)

OCP imports and instantiates cleanly under that combination. This unblocks hivemind-media-player's e2e (its PR #8).

> Note: stable consumers still get `1.3.1` (`<2.0.0`) from PyPI; a stable release carrying the `<3.0.0` cap (Release PR #193 / propose-stable) is the final step and is left to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
