### PR TITLE
fix(deps): allow ovos-workshop 9.x (widen <9.0.0 -> <10.0.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "ovos-plugin-manager>=0.0.26,<3.0.0",
     "ovos_bus_client>=0.0.7,<3.0.0",
     "ovos-utils>=0.1.0,<1.0.0",
-    "ovos-workshop>=2.4.2,<9.0.0",
+    "ovos-workshop>=2.4.2,<10.0.0",
     "padacioso>=0.1.1,<2.0.0",
     "dbus-next"
 ]


### PR DESCRIPTION
Last package in ovos-core's `mycroft` extra closure still capping `ovos-workshop<9.0.0`. Widen to `<10.0.0` so ovos-core can resolve its modern `ovos-workshop>=9.x` floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)