### PR TITLE
fix: align media intent tests with padacioso exact-match preference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "ovos_bus_client>=0.0.7,<3.0.0",
     "ovos-utils>=0.1.0,<1.0.0",
     "ovos-workshop>=2.4.2,<10.0.0",
-    "padacioso>=0.1.1,<2.0.0",
+    "padacioso>=1.1.1a1,<2.0.0",
     "dbus-next"
 ]
 
@@ -46,7 +46,7 @@ test = [
     "ovos-audio>=0.0.0,<2.0.0",
     "ovos-config>=0.0.13,<2.0.0",
     "ovos-utils>=0.1.0a17,<1.0.0",
-    "padacioso>=0.1.1,<2.0.0",
+    "padacioso>=1.1.1a1,<2.0.0",
     "PyYAML~=6.0"
 ]
 

--- a/test/unittests/test_media_intents.py
+++ b/test/unittests/test_media_intents.py
@@ -61,10 +61,11 @@ class TestEnglishMediaIntents(unittest.TestCase):
             self.media_intents.calc_intent("play music"),
             {'conf': 1, 'entities': {}, 'name': 'music'})
 
-        intent = self.media_intents.calc_intent("play some music")
-        self.assertEqual(intent['name'], 'music')
-        self.assertEqual(intent['entities'], {'query': 'some'})
-        self.assertGreaterEqual(intent['conf'], 0.9)
+        # "some" is a filler word matched by the exact
+        # "(play|start) (some|a) (music|song)" template, not a query
+        self.assertEqual(
+            self.media_intents.calc_intent("play some music"),
+            {'conf': 1.0, 'entities': {}, 'name': 'music'})
 
     def test_movie(self):
         intent = self.media_intents.calc_intent("play a horror film")
@@ -72,10 +73,11 @@ class TestEnglishMediaIntents(unittest.TestCase):
         self.assertEqual(intent['entities'], {'query': 'horror'})
         self.assertGreaterEqual(intent['conf'], 0.9)
 
-        intent = self.media_intents.calc_intent("play a movie")
-        self.assertEqual(intent['name'], 'movie')
-        self.assertEqual(intent['entities'], {'query': 'a'})
-        self.assertGreaterEqual(intent['conf'], 0.9)
+        # "a" is a filler word matched by the exact
+        # "(play|start) (a movie|movie|movies|film|films)" template, not a query
+        self.assertEqual(
+            self.media_intents.calc_intent("play a movie"),
+            {'conf': 1.0, 'entities': {}, 'name': 'movie'})
 
         intent = self.media_intents.calc_intent("play the matrix movie")
         self.assertEqual(intent['name'], 'movie')


### PR DESCRIPTION
## Summary

`test_media_intents::test_movie` and `test_music` fail on a clean `dev` checkout because padacioso now prefers exact non-wildcard templates over wildcard captures.

- "play a movie" matches the literal `(play|start) (a movie|movie|movies|film|films)` sample with conf 1.0 and no entities, instead of capturing the filler word "a" as `{query}`.
- "play some music" matches `(play|start) (some|a) (music|song)` with conf 1.0, instead of capturing "some" as `{query}`.

The new matches are the correct outcomes: filler words are not queries. The old expectations encoded incidental match ordering from earlier padacioso releases.

## Changes

- Update `test_movie` / `test_music` expectations to the exact-match results.
- Raise the padacioso floor to `>=1.1.1a1` (still `<2.0.0`) in `pyproject.toml` so dependency resolution yields the behavior the tests assert.

## Testing

Full suite passes locally in a fresh venv with prereleases allowed: 95 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)