### PR TITLE
fix: import EventSchedulerInterface from ovos_bus_client

### DIFF
--- a/ovos_plugin_common_play/ocp/gui.py
+++ b/ovos_plugin_common_play/ocp/gui.py
@@ -6,7 +6,7 @@ from time import sleep
 from ovos_bus_client.apis.gui import GUIInterface
 from ovos_bus_client.message import Message
 from ovos_config import Configuration
-from ovos_utils.events import EventSchedulerInterface
+from ovos_bus_client.apis.events import EventSchedulerInterface
 from ovos_utils.log import LOG
 from ovos_utils.ocp import MediaState, TrackState, PlaybackType, MediaType, Playlist, PluginStream, PlayerState, LoopState, dict2entry
 from ovos_plugin_common_play.ocp.constants import OCP_ID

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
     "ovos-plugin-manager>=0.0.26,<3.0.0",
-    "ovos_bus_client>=0.0.7,<3.0.0",
+    "ovos_bus_client>=2.7.0a1,<3.0.0",
     "ovos-utils>=0.1.0,<1.0.0",
     "ovos-workshop>=2.4.2,<10.0.0",
     "padacioso>=2.2.1a1,<3.0.0",

--- a/test/unittests/test_gui_event_scheduler.py
+++ b/test/unittests/test_gui_event_scheduler.py
@@ -1,0 +1,15 @@
+"""The GUI's EventSchedulerInterface comes from ovos_bus_client, not the
+deprecated ``ovos_utils.events`` location."""
+import unittest
+
+from ovos_plugin_common_play.ocp import gui
+
+
+class TestGuiEventScheduler(unittest.TestCase):
+    def test_event_scheduler_interface_from_bus_client(self):
+        self.assertTrue(
+            gui.EventSchedulerInterface.__module__.startswith("ovos_bus_client"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The OCP GUI imported `EventSchedulerInterface` from `ovos_utils.events`, which is deprecated — the class has moved to `ovos_bus_client.apis.events`.

The import now points at the new location. The `ovos_bus_client` floor is raised from `>=0.0.7` to `>=2.7.0a1`: the `apis.events` module only exists on the 2.x line (verified against the published wheels), and the module already relies on `ovos_bus_client.apis.gui` from that same line, so the old floor was stale.

Adds a regression test asserting the GUI's `EventSchedulerInterface` resolves from `ovos_bus_client`.